### PR TITLE
Use GFM for parsing

### DIFF
--- a/gemfiles/rails_5.gemfile.lock
+++ b/gemfiles/rails_5.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     maildown (3.1.0)
       actionmailer (>= 4.0.0)
-      kramdown
+      kramdown-parser-gfm
 
 GEM
   remote: https://rubygems.org/
@@ -58,7 +58,10 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    kramdown (2.1.0)
+    kramdown (2.2.1)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -98,6 +101,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.2)
+    rexml (3.2.4)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -126,4 +130,4 @@ DEPENDENCIES
   sqlite3 (~> 1.3.6)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     maildown (3.1.0)
       actionmailer (>= 4.0.0)
-      kramdown
+      kramdown-parser-gfm
 
 GEM
   remote: https://rubygems.org/
@@ -58,7 +58,10 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    kramdown (2.1.0)
+    kramdown (2.2.1)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -98,6 +101,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.2)
+    rexml (3.2.4)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -126,4 +130,4 @@ DEPENDENCIES
   sqlite3 (~> 1.3.6)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/gemfiles/rails_52.gemfile.lock
+++ b/gemfiles/rails_52.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     maildown (3.1.0)
       actionmailer (>= 4.0.0)
-      kramdown
+      kramdown-parser-gfm
 
 GEM
   remote: https://rubygems.org/
@@ -62,7 +62,10 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    kramdown (2.1.0)
+    kramdown (2.2.1)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -106,6 +109,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (12.3.2)
+    rexml (3.2.4)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -134,4 +138,4 @@ DEPENDENCIES
   sqlite3 (~> 1.3.6)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/gemfiles/rails_6.gemfile.lock
+++ b/gemfiles/rails_6.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     maildown (3.1.0)
       actionmailer (>= 4.0.0)
-      kramdown
+      kramdown-parser-gfm
 
 GEM
   remote: https://rubygems.org/
@@ -75,7 +75,10 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    kramdown (2.1.0)
+    kramdown (2.2.1)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     loofah (2.3.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -121,6 +124,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rake (13.0.0)
+    rexml (3.2.4)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -150,4 +154,4 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/gemfiles/rails_head.gemfile.lock
+++ b/gemfiles/rails_head.gemfile.lock
@@ -84,7 +84,7 @@ PATH
   specs:
     maildown (3.1.0)
       actionmailer (>= 4.0.0)
-      kramdown
+      kramdown-parser-gfm
 
 GEM
   remote: https://rubygems.org/
@@ -101,7 +101,10 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    kramdown (2.1.0)
+    kramdown (2.2.1)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -126,6 +129,7 @@ GEM
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
     rake (12.3.2)
+    rexml (3.2.4)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -155,4 +159,4 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/lib/maildown/markdown_engine.rb
+++ b/lib/maildown/markdown_engine.rb
@@ -49,7 +49,7 @@ module Maildown
     end
 
     def self.default_html_block
-      ->(string) { Kramdown::Document.new(string).to_html }
+      ->(string) { Kramdown::Document.new(string, input: "GFM").to_html }
     end
 
     def self.default_text_block

--- a/maildown.gemspec
+++ b/maildown.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "actionmailer", ">= 4.0.0"
-  s.add_dependency "kramdown"
+  s.add_dependency "kramdown-parser-gfm"
 
   s.add_development_dependency "railties"
   s.add_development_dependency "sqlite3"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require "rails/test_help"
-require "kramdown"
+require "kramdown-parser-gfm"
 
 Rails.backtrace_cleaner.remove_silencers!
 

--- a/test/unit/markdown_engine_test.rb
+++ b/test/unit/markdown_engine_test.rb
@@ -34,4 +34,10 @@ class MarkdownEngineTest < ActiveSupport::TestCase
     end
     thread.join
   end
+
+  test "handles code fences (GFM)" do
+    markdown = "```\nbar\n```"
+
+    assert_equal "<pre><code>bar\n</code></pre>", Maildown::MarkdownEngine.to_html(markdown)
+  end
 end


### PR DESCRIPTION
Change the default HTML block to use the Kramdown GFM parser, which
supports things like fenced code blocks.

This may be a breaking change, but note that GFM should be a superset of the
default kramdown parser, so the break would in most cases be that GFM that was
expected to be working, works.