### PR TITLE
Let an app load ActionMailer/ActionView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0
+
+- Delay loading of ActionMailer to fix support for `delivery_job` config (https://github.com/codetriage/maildown/pull/56)
+
 ## 3.2.0
 
 - Switch to "github style markdown" (https://github.com/codetriage/maildown/pull/54)

--- a/gemfiles/rails_5.gemfile.lock
+++ b/gemfiles/rails_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    maildown (3.1.0)
+    maildown (3.2.0)
       actionmailer (>= 4.0.0)
       kramdown-parser-gfm
 
@@ -58,7 +58,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    kramdown (2.2.1)
+    kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)

--- a/gemfiles/rails_51.gemfile.lock
+++ b/gemfiles/rails_51.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    maildown (3.1.0)
+    maildown (3.2.0)
       actionmailer (>= 4.0.0)
       kramdown-parser-gfm
 
@@ -58,7 +58,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    kramdown (2.2.1)
+    kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)

--- a/gemfiles/rails_52.gemfile.lock
+++ b/gemfiles/rails_52.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    maildown (3.1.0)
+    maildown (3.2.0)
       actionmailer (>= 4.0.0)
       kramdown-parser-gfm
 
@@ -62,7 +62,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    kramdown (2.2.1)
+    kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)

--- a/gemfiles/rails_6.gemfile.lock
+++ b/gemfiles/rails_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    maildown (3.1.0)
+    maildown (3.2.0)
       actionmailer (>= 4.0.0)
       kramdown-parser-gfm
 
@@ -75,7 +75,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    kramdown (2.2.1)
+    kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)

--- a/gemfiles/rails_head.gemfile.lock
+++ b/gemfiles/rails_head.gemfile.lock
@@ -82,7 +82,7 @@ GIT
 PATH
   remote: ..
   specs:
-    maildown (3.1.0)
+    maildown (3.2.0)
       actionmailer (>= 4.0.0)
       kramdown-parser-gfm
 
@@ -101,7 +101,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    kramdown (2.2.1)
+    kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)

--- a/lib/maildown.rb
+++ b/lib/maildown.rb
@@ -17,6 +17,10 @@ module Maildown
 end
 
 require 'maildown/markdown_engine'
-require 'maildown/ext/action_mailer'
-require 'maildown/ext/action_view'
+ActiveSupport.on_load(:action_mailer) do
+  require 'maildown/ext/action_mailer'
+end
+ActiveSupport.on_load(:action_view) do
+  require 'maildown/ext/action_view'
+end
 require 'maildown/handlers/markdown'

--- a/lib/maildown/ext/action_mailer.rb
+++ b/lib/maildown/ext/action_mailer.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'action_mailer'
-require 'action_mailer/base'
-
 # Monkeypatch to allow mailer to auto generate text/html
 #
 # If you generate a mailer action, by default it will only

--- a/lib/maildown/ext/action_view.rb
+++ b/lib/maildown/ext/action_view.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'action_view'
-
 # This monkeypatch allows the use of `.md.erb` file extensions
 # in addition to `.md+erb` and `.md`
 module ActionView


### PR DESCRIPTION
Hi there and thanks for the work on Maildown!

We noticed an issue with Maildown as we were upgrading to Rails 6.0.

Requiring ActionMailer while the gem is loading might break initialization logic of a Rails app using Rails 6.0 or later.

ActionMailer 6.0 introduces the new [`delivery_job`](https://github.com/rails/rails/blob/6-0-stable/actionmailer/lib/action_mailer/railtie.rb#L49-L51) setting whose value is being constantized and applied as soon as ActionMailer is loaded. Normally, the delivery job would be configured during the app initialization, so if ActionMailer is loaded **before** the initializer is being executed, the configuration won’t be applied and a default `delivery_job` class would be used.

The problem here is that Maildown is required before Rails initializers run, and it forces loading of ActionMailer by requiring
`ActionMailer::Base` for monkey-patching. This causes ActionMailer to never apply `delivery_job` config.

The solution seems simple enough: delay monkey-patching until ActionMailer is loaded.

Because it's easy and seems safer, we'll also delay monkey-patching of ActionView until it's loaded as well.

This fix seems almost too easy, but all tests are passing and the app works as expected, hopefully I didn't miss something. Well, one thing is that there's now an explicit dependency on ActiveSupport and we don't require it, but I can't tell under which scenario that might be a problem.

I also couldn't figure out how to write a test case for this scenario that wouldn't break on pre-6 Rails.